### PR TITLE
Update GPS plugin to allow connecting to GPSD

### DIFF
--- a/pwnagotchi/defaults.toml
+++ b/pwnagotchi/defaults.toml
@@ -33,7 +33,7 @@ main.plugins.net-pos.api_key = "test"
 
 main.plugins.gps.enabled = false
 main.plugins.gps.speed = 19200
-main.plugins.gps.device = "/dev/ttyUSB0"
+main.plugins.gps.device = "/dev/ttyUSB0" # for GPSD: "localhost:2947"
 
 main.plugins.webgpsmap.enabled = false
 

--- a/pwnagotchi/plugins/default/gps.py
+++ b/pwnagotchi/plugins/default/gps.py
@@ -25,7 +25,7 @@ class GPS(plugins.Plugin):
         logging.info(f"gps plugin loaded for {self.options['device']}")
 
     def on_ready(self, agent):
-        if os.path.exists(self.options["device"]):
+        if os.path.exists(self.options["device"]) or ":" in self.options["device"]:
             logging.info(
                 f"enabling bettercap's gps module for {self.options['device']}"
             )


### PR DESCRIPTION
Bettercap supports connecting to a GPSD server with hostname:port since v2.29.  This allows users to use GPSD/chrony to set the system clock while still being able to use the GPS plugin.

Signed-off-by: llamasoft <llamasoft@rm-rf.email>
